### PR TITLE
Fix AddAction extension to use GRDB after migration

### DIFF
--- a/Develop/Client-Develop.xcodeproj/project.pbxproj
+++ b/Develop/Client-Develop.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		2B4620A12988149C00C0619C /* FeatureFlags+Impl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B4620A02988149C00C0619C /* FeatureFlags+Impl.swift */; };
 		2B4680352826B88A005AA211 /* Presentation in Frameworks */ = {isa = PBXBuildFile; productRef = 2B4680342826B88A005AA211 /* Presentation */; };
 		2B5C8CA52EE5D787006E0B97 /* MigrationCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2B5C8CA42EE5D787006E0B97 /* MigrationCore */; };
+		2B5C8CA62EE5D788006E0B97 /* MigrationCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2B5C8CA82EE5D789006E0B97 /* MigrationCore */; };
 		2B5CD8A82A46D9B2007EFFEF /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2B5CD8A72A46D9B2007EFFEF /* InfoPlist.xcstrings */; };
 		2B5CD8AA2A46D9B2007EFFEF /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2B5CD8A92A46D9B2007EFFEF /* Localizable.xcstrings */; };
 		2B5F955D2B9946AB00CE092E /* GenreClientLive in Frameworks */ = {isa = PBXBuildFile; productRef = 2B5F955C2B9946AB00CE092E /* GenreClientLive */; };
@@ -185,6 +186,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2B5C8CA62EE5D788006E0B97 /* MigrationCore in Frameworks */,
 				2B0167EB2AF3FE95008F8BB9 /* TagClientLive in Frameworks */,
 				2B23310B2AD2EEDA005DF076 /* Infrastructure in Frameworks */,
 				2B0167DF2AF3F981008F8BB9 /* SearchClientLive in Frameworks */,
@@ -437,6 +439,7 @@
 				2B0167DE2AF3F981008F8BB9 /* SearchClientLive */,
 				2B0167EA2AF3FE95008F8BB9 /* TagClientLive */,
 				2B1963422BAA98E700B33496 /* ShelfClientLive */,
+				2B5C8CA82EE5D789006E0B97 /* MigrationCore */,
 			);
 			productName = AddActionExtension;
 			productReference = 2B6458392AD2B9D700AD4870 /* AddActionExtension.appex */;
@@ -1317,6 +1320,10 @@
 			productName = Presentation;
 		};
 		2B5C8CA42EE5D787006E0B97 /* MigrationCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MigrationCore;
+		};
+		2B5C8CA82EE5D789006E0B97 /* MigrationCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MigrationCore;
 		};

--- a/Production/Client.xcodeproj/project.pbxproj
+++ b/Production/Client.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		2B46209F2988142D00C0619C /* FeatureFlags+Impl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B46209E2988142D00C0619C /* FeatureFlags+Impl.swift */; };
 		2B4680352826B88A005AA211 /* Presentation in Frameworks */ = {isa = PBXBuildFile; productRef = 2B4680342826B88A005AA211 /* Presentation */; };
 		2B5C8CA72EE5D794006E0B97 /* MigrationCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2B5C8CA62EE5D794006E0B97 /* MigrationCore */; };
+		2B5C8CA82EE5D795006E0B97 /* MigrationCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2B5C8CA92EE5D796006E0B97 /* MigrationCore */; };
 		2B5CD8AD2A46DA50007EFFEF /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2B5CD8AB2A46DA50007EFFEF /* InfoPlist.xcstrings */; };
 		2B5CD8AE2A46DA50007EFFEF /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 2B5CD8AC2A46DA50007EFFEF /* Localizable.xcstrings */; };
 		2B5F955F2B9946B200CE092E /* GenreClientLive in Frameworks */ = {isa = PBXBuildFile; productRef = 2B5F955E2B9946B200CE092E /* GenreClientLive */; };
@@ -176,6 +177,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2B5C8CA82EE5D795006E0B97 /* MigrationCore in Frameworks */,
 				2B22853E2AF4C75800A5F2AA /* TagClientLive in Frameworks */,
 				2B2331132AD2EEEE005DF076 /* Infrastructure in Frameworks */,
 				2B22853C2AF4C75000A5F2AA /* SearchClientLive in Frameworks */,
@@ -419,6 +421,7 @@
 				2B22853B2AF4C75000A5F2AA /* SearchClientLive */,
 				2B22853D2AF4C75800A5F2AA /* TagClientLive */,
 				2B19633E2BAA98C400B33496 /* ShelfClientLive */,
+				2B5C8CA92EE5D796006E0B97 /* MigrationCore */,
 			);
 			productName = AddActionExtension;
 			productReference = 2B64584E2AD2B9F000AD4870 /* AddActionExtension.appex */;
@@ -1172,6 +1175,10 @@
 			productName = Presentation;
 		};
 		2B5C8CA62EE5D794006E0B97 /* MigrationCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = MigrationCore;
+		};
+		2B5C8CA92EE5D796006E0B97 /* MigrationCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = MigrationCore;
 		};


### PR DESCRIPTION
## Summary
- AddAction拡張機能がマイグレーション状態に応じてShelfClientを切り替えるよう修正
- Widget.swiftと同じパターンを使用してGRDB版とSwiftData版を適切に選択
- DevelopとProductionの両プロジェクトにMigrationCore依存関係を追加

## Test plan
- [ ] アプリをビルドして実行
- [ ] Safariや別アプリでAmazonの本のページを開く
- [ ] 共有シートからAddAction拡張機能を起動
- [ ] 本を登録
- [ ] メインアプリを開き、本棚画面に新しい本が表示されることを確認
- [ ] アプリを再起動して、保存された本が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated MigrationCore Swift package dependency into the build system across multiple targets and frameworks.
  * Updated build configuration to properly link MigrationCore dependencies.

* **Refactor**
  * Updated storage implementation selection logic to choose between alternate storage backends based on application state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->