### PR TITLE
ci: add caching for SPM, DerivedData, and tools to speed up CI

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -18,6 +18,27 @@ jobs:
       - uses: ruby/setup-ruby@v1.283.0
         with:
           bundler-cache: true
+      - name: Cache SPM packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            .build
+          key: spm-${{ runner.os }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            spm-${{ runner.os }}-
+      - name: Cache DerivedData
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: deriveddata-${{ runner.os }}-${{ hashFiles('**/*.swift', '**/Package.resolved') }}
+          restore-keys: |
+            deriveddata-${{ runner.os }}-
+      - name: Cache tools
+        uses: actions/cache@v4
+        with:
+          path: tools
+          key: tools-${{ runner.os }}-${{ hashFiles('scripts/tool/*.sh') }}
       - name: Bootstrap
         run: make bootstrap
         env:

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -21,4 +21,4 @@ set -o pipefail && env NSUnbufferedIO=YES \
   -resultBundlePath ${GIT_REPO}/test_output/Tests.xcresult \
   -enableCodeCoverage YES \
   -skipMacroValidation \
-  clean test 2>&1 | ${GIT_REPO}/tools/xcbeautify
+  test 2>&1 | ${GIT_REPO}/tools/xcbeautify


### PR DESCRIPTION
## Summary
- Add `actions/cache@v4` for SPM packages (`~/Library/Caches/org.swift.swiftpm`, `.build`)
- Add `actions/cache@v4` for DerivedData (`~/Library/Developer/Xcode/DerivedData`)
- Add `actions/cache@v4` for build tools (`tools/`)
- Remove `clean` from xcodebuild to enable incremental builds

## Test plan
- [ ] Run CI workflow twice and verify cache hit on second run
- [ ] Check Actions logs for cache restore/save messages
- [ ] Compare execution time between first and subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD build performance by implementing build artifact caching for faster subsequent runs.
  * Optimized unit test execution process by streamlining the build flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->