### PR TITLE
Update XcodeBuildMCP to v2.0.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "xcodebuildmcp@latest"
+        "xcodebuildmcp@2.0.0"
       ],
       "env": {
         "INCREMENTAL_BUILDS_ENABLED": "true",


### PR DESCRIPTION
## Changes
- `xcodebuildmcp@1.7.0` → `@latest` (v2.0.0)

## Notes
- v2.0 でツール名が大幅リネーム（例: `list_schems_ws` → `list_schemes`）
- CLAUDE.md にツール名の直接参照はないため、`.mcp.json` の更新のみ
- PR #50 の typo コメント（`list_schems_ws` → `list_schemes_ws`）はこの更新で不要になります

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Xcode build integration package to v2.0.0.
  * Package version change only; no configuration, behavior, or public API changes.
  * No runtime impact expected and review effort is minimal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->