### PR TITLE
Add MigrationFeature and DataManagementFeature unit tests

### DIFF
--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -55,6 +55,8 @@ extension String {
 
     // Tests
     static let BookCoreTests = "BookCoreTests"
+    static let DataManagementCoreTests = "DataManagementCoreTests"
+    static let MigrationCoreTests = "MigrationCoreTests"
     static let StatisticsCoreTests = "StatisticsCoreTests"
 }
 
@@ -291,6 +293,18 @@ let testTargets: [Target] = [
         dependencies: [
             .target(name: .BookCore),
             .target(name: .SettingsCore),
+        ]
+    ),
+    .testTarget(
+        name: .DataManagementCoreTests,
+        dependencies: [
+            .target(name: .DataManagementCore),
+        ]
+    ),
+    .testTarget(
+        name: .MigrationCoreTests,
+        dependencies: [
+            .target(name: .MigrationCore),
         ]
     ),
     .testTarget(

--- a/Core/Tests/DataManagementCoreTests/DataManagementFeatureTests.swift
+++ b/Core/Tests/DataManagementCoreTests/DataManagementFeatureTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import DataManagementCore
+import ComposableArchitecture
+import DataClient
+
+final class DataManagementFeatureTests: XCTestCase {
+    @MainActor
+    func test_onLoad_exportSuccess_jsonSet() async {
+        let store = TestStore(initialState: DataManagementFeature.State()) {
+            DataManagementFeature()
+        } withDependencies: {
+            $0[DataClient.self].export = { "{\"books\":[]}" }
+        }
+
+        await store.send(.screen(.onLoad))
+        await store.receive(\.internal.loaded) {
+            $0.json = "{\"books\":[]}"
+        }
+    }
+
+    @MainActor
+    func test_onLoad_exportFailure_alertShown() async {
+        struct ExportError: Error, LocalizedError {
+            var errorDescription: String? { "Export failed" }
+        }
+
+        let store = TestStore(initialState: DataManagementFeature.State()) {
+            DataManagementFeature()
+        } withDependencies: {
+            $0[DataClient.self].export = { throw ExportError() }
+        }
+
+        await store.send(.screen(.onLoad))
+        await store.receive(\.internal.loaded) {
+            $0.alert = AlertState {
+                TextState(String(localized: "alert.title.load_failed"))
+            } actions: {
+                ButtonState(action: .dismiss) {
+                    TextState("OK")
+                }
+            } message: {
+                TextState("Export failed")
+            }
+        }
+    }
+
+    @MainActor
+    func test_imported_success_alertShown() async {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("test.json")
+        try! Data("{\"books\":[]}".utf8).write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let store = TestStore(initialState: DataManagementFeature.State()) {
+            DataManagementFeature()
+        } withDependencies: {
+            $0[DataClient.self].import = { @Sendable _ in }
+        }
+
+        await store.send(.screen(.imported(tempURL)))
+        await store.receive(\.internal.imported) {
+            $0.alert = AlertState {
+                TextState(String(localized: "import_completed_title"))
+            } actions: {
+                ButtonState(action: .dismiss) {
+                    TextState("OK")
+                }
+            } message: {
+                TextState(String(localized: "alert.message.import_success_simple"))
+            }
+        }
+    }
+
+    @MainActor
+    func test_imported_failure_errorAlertShown() async {
+        struct ImportError: Error, LocalizedError {
+            var errorDescription: String? { "Import failed" }
+        }
+
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("test.json")
+        try! Data("{\"books\":[]}".utf8).write(to: tempURL)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let store = TestStore(initialState: DataManagementFeature.State()) {
+            DataManagementFeature()
+        } withDependencies: {
+            $0[DataClient.self].import = { @Sendable _ in throw ImportError() }
+        }
+
+        await store.send(.screen(.imported(tempURL)))
+        await store.receive(\.internal.imported) {
+            $0.alert = AlertState {
+                TextState(String(localized: "alert.title.import_failed"))
+            } actions: {
+                ButtonState(action: .dismiss) {
+                    TextState("OK")
+                }
+            } message: {
+                TextState("Import failed")
+            }
+        }
+    }
+
+    @MainActor
+    func test_alertDismiss_alertCleared() async {
+        var state = DataManagementFeature.State()
+        state.alert = AlertState {
+            TextState("Test")
+        } actions: {
+            ButtonState(action: .dismiss) {
+                TextState("OK")
+            }
+        }
+
+        let store = TestStore(initialState: state) {
+            DataManagementFeature()
+        }
+
+        await store.send(.alert(.presented(.dismiss))) {
+            $0.alert = nil
+        }
+    }
+}

--- a/Core/Tests/MigrationCoreTests/MigrationFeatureTests.swift
+++ b/Core/Tests/MigrationCoreTests/MigrationFeatureTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import MigrationCore
+import ComposableArchitecture
+
+final class MigrationFeatureTests: XCTestCase {
+    @MainActor
+    func test_onAppear_migrationNeeded_setsIdleWithBookCount() async {
+        let store = TestStore(initialState: MigrationFeature.State()) {
+            MigrationFeature()
+        } withDependencies: {
+            $0.migrationClient.requiresMigration = { true }
+            $0.migrationClient.getBookCount = { 42 }
+        }
+
+        await store.send(.screen(.onAppear))
+        await store.receive(\.internal.checkMigrationNeeded) {
+            $0.migrationState = .checking
+        }
+        await store.receive(\.internal.migrationCheckCompleted) {
+            $0.migrationState = .idle
+            $0.bookCount = 42
+        }
+    }
+
+    @MainActor
+    func test_onAppear_migrationNotNeeded_completedAndFinished() async {
+        let store = TestStore(initialState: MigrationFeature.State()) {
+            MigrationFeature()
+        } withDependencies: {
+            $0.migrationClient.requiresMigration = { false }
+        }
+
+        await store.send(.screen(.onAppear))
+        await store.receive(\.internal.checkMigrationNeeded) {
+            $0.migrationState = .checking
+        }
+        await store.receive(\.internal.migrationCheckCompleted) {
+            $0.migrationState = .completed
+        }
+        await store.receive(\.external.migrationFinished)
+    }
+
+    @MainActor
+    func test_startMigration_success_completedWithAlert() async {
+        let store = TestStore(initialState: MigrationFeature.State(migrationState: .idle)) {
+            MigrationFeature()
+        } withDependencies: {
+            $0.migrationClient.performMigration = {}
+            $0.migrationClient.markCompleted = {}
+        }
+
+        await store.send(.screen(.startMigration)) {
+            $0.migrationState = .migrating(progress: 0)
+        }
+        await store.receive(\.internal.performMigration)
+        await store.receive(\.internal.migrationCompleted) {
+            $0.migrationState = .completed
+            $0.completionAlert = AlertState {
+                TextState("alert.title.migration_completed")
+            } actions: {
+                ButtonState(action: .dismiss) {
+                    TextState("button.title.close")
+                }
+            } message: {
+                TextState("alert.message.migration_completed")
+            }
+        }
+    }
+
+    @MainActor
+    func test_startMigration_failure_failedState() async {
+        struct MigrationError: Error, LocalizedError {
+            var errorDescription: String? { "Migration failed" }
+        }
+
+        let store = TestStore(initialState: MigrationFeature.State(migrationState: .idle)) {
+            MigrationFeature()
+        } withDependencies: {
+            $0.migrationClient.performMigration = { throw MigrationError() }
+        }
+
+        await store.send(.screen(.startMigration)) {
+            $0.migrationState = .migrating(progress: 0)
+        }
+        await store.receive(\.internal.performMigration)
+        await store.receive(\.internal.migrationFailed) {
+            $0.migrationState = .failed(error: "Migration failed")
+        }
+    }
+
+    @MainActor
+    func test_skipMigration_dismissCalled() async {
+        let store = TestStore(initialState: MigrationFeature.State()) {
+            MigrationFeature()
+        }
+
+        await store.send(.screen(.skipMigration))
+    }
+
+    @MainActor
+    func test_alertDismiss_delegateAndExternal() async {
+        var state = MigrationFeature.State(migrationState: .completed)
+        state.completionAlert = AlertState {
+            TextState("alert.title.migration_completed")
+        } actions: {
+            ButtonState(action: .dismiss) {
+                TextState("button.title.close")
+            }
+        } message: {
+            TextState("alert.message.migration_completed")
+        }
+
+        let store = TestStore(initialState: state) {
+            MigrationFeature()
+        }
+
+        await store.send(.alert(.presented(.dismiss))) {
+            $0.completionAlert = nil
+        }
+        await store.receive(\.delegate.migrationCompleted)
+        await store.receive(\.external.migrationFinished)
+    }
+
+    @MainActor
+    func test_checkMigrationNeeded_failure_failedState() async {
+        struct CheckError: Error, LocalizedError {
+            var errorDescription: String? { "Check failed" }
+        }
+
+        let store = TestStore(initialState: MigrationFeature.State()) {
+            MigrationFeature()
+        } withDependencies: {
+            $0.migrationClient.requiresMigration = { throw CheckError() }
+        }
+
+        await store.send(.screen(.onAppear))
+        await store.receive(\.internal.checkMigrationNeeded) {
+            $0.migrationState = .checking
+        }
+        await store.receive(\.internal.migrationFailed) {
+            $0.migrationState = .failed(error: "Check failed")
+        }
+    }
+}

--- a/Develop/Client Develop.xctestplan
+++ b/Develop/Client Develop.xctestplan
@@ -41,6 +41,20 @@
     },
     {
       "target" : {
+        "containerPath" : "container:..\/Core",
+        "identifier" : "DataManagementCoreTests",
+        "name" : "DataManagementCoreTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Core",
+        "identifier" : "MigrationCoreTests",
+        "name" : "MigrationCoreTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:..\/Infrastructure",
         "identifier" : "InfrastructureTests",
         "name" : "InfrastructureTests"

--- a/Develop/Client-Develop.xcodeproj/xcshareddata/xcschemes/Client Develop.xcscheme
+++ b/Develop/Client-Develop.xcodeproj/xcshareddata/xcschemes/Client Develop.xcscheme
@@ -82,6 +82,26 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DataManagementCoreTests"
+               BuildableName = "DataManagementCoreTests"
+               BlueprintName = "DataManagementCoreTests"
+               ReferencedContainer = "container:../Core">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MigrationCoreTests"
+               BuildableName = "MigrationCoreTests"
+               BlueprintName = "MigrationCoreTests"
+               ReferencedContainer = "container:../Core">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "PresentationTests"
                BuildableName = "PresentationTests"
                BlueprintName = "PresentationTests"


### PR DESCRIPTION
## Summary

Add TCA unit tests for MigrationFeature and DataManagementFeature.

### MigrationCoreTests (7 tests)
- `onAppear` → migration needed → idle state with book count
- `onAppear` → migration not needed → completed + migrationFinished
- `startMigration` → success → completed + alert
- `startMigration` → failure → failed state
- `skipMigration` → dismiss
- Alert dismiss → delegate + external actions
- `checkMigrationNeeded` failure → failed state

### DataManagementCoreTests (5 tests)
- `onLoad` → export success → json set
- `onLoad` → export failure → alert
- `imported` → success → success alert
- `imported` → failure → error alert
- Alert dismiss → alert cleared

Closes #66, Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage with new test suites for data management and migration features, including comprehensive tests for import/export functionality and migration workflows.

* **Chores**
  * Updated dependencies: Firebase iOS SDK (12.8.0→12.9.0), SQLite Data (1.5.0→1.5.1), Swift Snapshot Testing (1.18.7→1.18.9), and Swift Structured Queries (0.27.0→0.30.0).
  * Configured test targets and schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->