### PR TITLE
SettingsFeature のユニットテスト追加

### DIFF
--- a/Bookshelf.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bookshelf.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "92ffcbf24767576bb5caf3c0cce74bd54f34c8e02605a3ed397bc2c9f529a14c",
+  "originHash" : "00c22ad7b3114ba54e80dd1b3e130a1b10c63e4a0576bb853bff87088be6df76",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk.git",
       "state" : {
-        "revision" : "674d9a7ee9858207181a3dd0b42c77298c6fb71b",
-        "version" : "12.8.0"
+        "revision" : "9b3aed4fa6226125305b82d4d86c715bef250785",
+        "version" : "12.9.0"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/sqlite-data.git",
       "state" : {
-        "revision" : "57274d587b564a0b420bd4fa2bec479aac5323a2",
-        "version" : "1.5.0"
+        "revision" : "05704b563ecb7f0bd7e49b6f360a6383a3e53e7d",
+        "version" : "1.5.1"
       }
     },
     {
@@ -285,8 +285,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
-        "version" : "1.18.7"
+        "revision" : "bf8d8c27f0f0c6d5e77bff0db76ab68f2050d15d",
+        "version" : "1.18.9"
       }
     },
     {
@@ -294,8 +294,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "862802b5a66aec04219b7c2a10e06a5681da86ee",
-        "version" : "0.27.0"
+        "revision" : "d8163b3a98f3c8434c4361e85126db449d84bc66",
+        "version" : "0.30.0"
       }
     },
     {

--- a/Core/Package.swift
+++ b/Core/Package.swift
@@ -290,6 +290,7 @@ let testTargets: [Target] = [
         name: .BookCoreTests,
         dependencies: [
             .target(name: .BookCore),
+            .target(name: .SettingsCore),
         ]
     ),
     .testTarget(

--- a/Core/Tests/BookCoreTests/SettingsFeatureTests.swift
+++ b/Core/Tests/BookCoreTests/SettingsFeatureTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+@testable import SettingsCore
+import ComposableArchitecture
+import RemindModel
+import RemindClient
+import SyncClient
+import Application
+import Device
+import FeatureFlags
+import MigrationCore
+import SyncModel
+import Foundation
+
+final class SettingsFeatureTests: XCTestCase {
+
+    // MARK: - onLoad
+
+    @MainActor
+    func test_onLoad_setsFeatureFlags() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        } withDependencies: {
+            $0[FeatureFlags.self].enablePurchase = { false }
+            $0[MigrationClient.self].isCompleted = { true }
+        }
+
+        await store.send(.screen(.onLoad)) {
+            $0.enablePurchase = false
+            $0.isMigrationCompleted = true
+        }
+    }
+
+    // MARK: - task (enablePurchase = false)
+
+    @MainActor
+    func test_task_withoutPurchase_loadsSettings() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        } withDependencies: {
+            $0[SyncClient.self].fetch = { Sync(enabled: true) }
+            $0[RemindClient.self].fetch = { .disabled }
+            $0[Application.self].version = { "1.0.0" }
+            $0[Application.self].build = { 42 }
+            $0[Device.self].isProfileInstalled = { false }
+        }
+
+        await store.send(.screen(.task))
+        await store.receive(\.internal.load)
+        await store.receive(\.internal.loaded) {
+            $0.isSyncEnabled = true
+            $0.remind = .disabled
+            $0.version = "1.0.0"
+            $0.build = "42"
+            $0.isProfileInstalled = false
+        }
+    }
+
+    // MARK: - syncEnabledChanged
+
+    @MainActor
+    func test_syncEnabledChanged_updatesState() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        } withDependencies: {
+            $0[SyncClient.self].update = { _ in }
+        }
+
+        await store.send(.screen(.syncEnabledChanged(true))) {
+            $0.isSyncEnabled = true
+        }
+    }
+
+    // MARK: - remindEnabledChanged
+
+    @MainActor
+    func test_remindEnabledChanged_true_setsDefaultRemind() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        } withDependencies: {
+            $0[RemindClient.self].update = { _ in }
+        }
+
+        await store.send(.screen(.remindEnabledChanged(true))) {
+            $0.remind = .make(.saturday)
+        }
+    }
+
+    @MainActor
+    func test_remindEnabledChanged_false_disablesRemind() async {
+        var initialState = SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        initialState.remind = .make(.saturday)
+
+        let store = TestStore(initialState: initialState) {
+            SettingsFeature()
+        } withDependencies: {
+            $0[RemindClient.self].update = { _ in }
+        }
+
+        await store.send(.screen(.remindEnabledChanged(false))) {
+            $0.remind = .disabled
+        }
+    }
+
+    // MARK: - dayOfWeekChanged
+
+    @MainActor
+    func test_dayOfWeekChanged_updatesRemindSetting() async {
+        var initialState = SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        initialState.remind = .make(.saturday)
+
+        let store = TestStore(initialState: initialState) {
+            SettingsFeature()
+        } withDependencies: {
+            $0[RemindClient.self].update = { _ in }
+        }
+
+        await store.send(.screen(.dayOfWeekChanged(.monday))) {
+            $0.remind = .enabled(.init(dayOfWeek: .monday, hour: 9))
+        }
+    }
+
+    @MainActor
+    func test_dayOfWeekChanged_whenDisabled_doesNothing() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        }
+
+        await store.send(.screen(.dayOfWeekChanged(.monday)))
+    }
+
+    // MARK: - navigation
+
+    @MainActor
+    func test_onSupportTapped_presentsSupport() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        }
+
+        await store.send(.screen(.onSupportTapped)) {
+            $0.destination = .support(.init(groupID: "group.com.bivre.bookshelf"))
+        }
+    }
+
+    @MainActor
+    func test_onMigrationTapped_presentsMigration() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        }
+
+        await store.send(.screen(.onMigrationTapped)) {
+            $0.destination = .migration(.init())
+        }
+    }
+
+    @MainActor
+    func test_onDataManagementTapped_presentsDataManagement() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        }
+
+        await store.send(.screen(.onDataManagementTapped)) {
+            $0.destination = .dataManagement(.init())
+        }
+    }
+
+    @MainActor
+    func test_onNetworkTapped_activatesNetwork() async {
+        let store = TestStore(
+            initialState: SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        ) {
+            SettingsFeature()
+        }
+
+        await store.send(.screen(.onNetworkTapped)) {
+            $0.isNetworkActived = true
+        }
+    }
+
+    @MainActor
+    func test_onNetworkDismissed_deactivatesNetwork() async {
+        var initialState = SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        initialState.isNetworkActived = true
+
+        let store = TestStore(initialState: initialState) {
+            SettingsFeature()
+        }
+
+        await store.send(.screen(.onNetworkDismissed(false))) {
+            $0.isNetworkActived = false
+        }
+    }
+
+    // MARK: - destination dismiss
+
+    @MainActor
+    func test_destinationDismiss_clearsDestination() async {
+        var initialState = SettingsFeature.State.make(isSyncEnabled: false, groupID: "group.com.bivre.bookshelf")
+        initialState.destination = .dataManagement(.init())
+
+        let store = TestStore(initialState: initialState) {
+            SettingsFeature()
+        }
+
+        await store.send(.destination(.dismiss)) {
+            $0.destination = nil
+        }
+    }
+}


### PR DESCRIPTION
## 概要
#67 の対応。SettingsFeature の TCA ユニットテストを13件追加。

## テスト内容
- `onLoad`: FeatureFlags・MigrationClient の反映
- `task`: SyncClient/RemindClient/Application/Device からの設定読み込み
- `syncEnabledChanged`: iCloud 同期の有効/無効切り替え
- `remindEnabledChanged`: リマインド有効/無効切り替え
- `dayOfWeekChanged`: 曜日変更・disabled 時の無操作
- ナビゲーション: Support/Migration/DataManagement/Network 画面遷移
- `destination dismiss`: destination クリア

## 備考
- XCTest フレームワークを使用（Swift Testing は Swift 6.2.3 の IRGen クラッシュ回避のため不使用）
- `BookCoreTests` に `SettingsCore` 依存を追加
- 全53テスト PASS 確認済み

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dependency packages to latest stable versions for enhanced stability and performance.

* **Tests**
  * Expanded test coverage for settings feature functionality to improve code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->