### PR TITLE
PR にテストカバレッジレポートを表示する

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -49,8 +49,13 @@ jobs:
         env:
           TEST_OS: 26.2
           TEST_DEVICE: iPhone 17 Pro
-      - uses: kishikawakatsumi/xcresulttool@v1
-        with:
-          path: test_output/Tests.xcresult
+      - name: Convert coverage to Codecov format
         if: success() || failure()
-        continue-on-error: true
+        run: |
+          xcrun xccov view --report --json test_output/Tests.xcresult > coverage.json
+      - name: Upload to Codecov
+        if: success() || failure()
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.json
+          fail_ci_if_error: false


### PR DESCRIPTION
## 概要
#58 の対応。PR の Checks タブにテスト結果とカバレッジレポートを表示する。

## 変更内容
- `run_unit_tests.yml` に [kishikawakatsumi/xcresulttool](https://github.com/kishikawakatsumi/xcresulttool) アクションを追加
- テスト成功・失敗どちらの場合もレポートを生成（`if: success() || failure()`）
- 既存の `-resultBundlePath` と `-enableCodeCoverage YES` をそのまま活用

## 確認方法
この PR 自体の Checks タブでレポートが表示されることを確認してください。

Closes #58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now converts test coverage to a Codecov-compatible format and uploads coverage reports.
  * Coverage processing runs regardless of test success or failure and is configured not to fail the pipeline if errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->