### PR TITLE
CI: main push 時にもユニットテスト + Codecov を実行

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -1,6 +1,8 @@
 name: Run unit tests
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
## 概要
Codecov が PR のカバレッジ差分を表示するには、ベースブランチ（main）のカバレッジレポートが必要です。

## 変更内容
- `run_unit_tests.yml` のトリガーに `push: branches: [main]` を追加
- main へのマージ時にもテスト実行 + Codecov アップロードが走るようになる

## 効果
これにより、以降の PR で Codecov のカバレッジ差分コメントが表示されるようになります。