### PR TITLE
Maestro E2E テストを拡充する

### DIFF
--- a/.github/workflows/run_e2e_tests.yml
+++ b/.github/workflows/run_e2e_tests.yml
@@ -55,7 +55,7 @@ jobs:
           xcrun simctl privacy "${MAESTRO_DEVICE_ID}" grant all com.bivre.bookshelf.develop
 
       - name: Run E2E Tests
-        run: maestro test --timeout 120000 .maestro
+        run: maestro test --timeout 300000 .maestro
 
       - name: Upload Test Results
         if: always()

--- a/.maestro/_common/_add_sample_book.yaml
+++ b/.maestro/_common/_add_sample_book.yaml
@@ -1,0 +1,39 @@
+appId: com.bivre.bookshelf.develop
+---
+- runFlow: ../common/flows/_open_app.yaml
+
+# 追加ボタンをタップ
+- tapOn: "書籍の登録"
+
+# 追加画面が開くことを確認
+- waitForAnimationToEnd
+- assertVisible: "書籍の登録"
+
+# 検索フィールドに入力
+- tapOn:
+    text: "Search"
+    optional: true
+- inputText: "Swift"
+
+# 検索実行
+- pressKey: Enter
+
+# 検索結果を待機
+- extendedWaitUntil:
+    visible: ".*"
+    timeout: 10000
+
+- waitForAnimationToEnd
+
+# 最初の検索結果をタップ
+- tapOn:
+    index: 0
+
+- waitForAnimationToEnd
+
+# 登録ボタンをタップ
+- tapOn: "登録する"
+
+# 本棚に戻ることを確認
+- waitForAnimationToEnd
+- assertVisible: "本棚"

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -11,3 +11,7 @@ screenshotDir: .maestro/screenshots
 
 flows:
   - 'smoke/*'
+  - 'crud/*'
+  - 'search/*'
+  - 'statistics/*'
+  - 'settings/*'

--- a/.maestro/crud/01_book_detail_view.yaml
+++ b/.maestro/crud/01_book_detail_view.yaml
@@ -1,0 +1,17 @@
+appId: com.bivre.bookshelf.develop
+---
+# 前提: 本を1冊追加
+- runFlow: ../_common/_add_sample_book.yaml
+
+# 追加した本をタップして詳細画面へ
+- tapOn:
+    text: ".*Swift.*"
+    index: 0
+
+- waitForAnimationToEnd
+
+# 詳細画面の要素を確認
+- assertVisible: "詳細"
+- assertVisible: "購入"
+- assertVisible: "ステータス"
+- assertVisible: "タグ"

--- a/.maestro/crud/02_book_delete.yaml
+++ b/.maestro/crud/02_book_delete.yaml
@@ -1,0 +1,24 @@
+appId: com.bivre.bookshelf.develop
+---
+# 前提: 本を1冊追加
+- runFlow: ../_common/_add_sample_book.yaml
+
+# 追加した本をタップして詳細画面へ
+- tapOn:
+    text: ".*Swift.*"
+    index: 0
+
+- waitForAnimationToEnd
+
+# 削除ボタンをタップ
+- tapOn: "書籍の削除"
+
+- waitForAnimationToEnd
+
+# 確認ダイアログで削除を実行
+- tapOn: "削除"
+
+- waitForAnimationToEnd
+
+# 本棚に戻ったことを確認
+- assertVisible: "本棚"

--- a/.maestro/search/01_shelf_search.yaml
+++ b/.maestro/search/01_shelf_search.yaml
@@ -1,0 +1,18 @@
+appId: com.bivre.bookshelf.develop
+---
+# 前提: 本を1冊追加
+- runFlow: ../_common/_add_sample_book.yaml
+
+# 本棚画面で検索バーをタップ
+- tapOn:
+    text: "Search"
+    optional: true
+
+# 検索テキストを入力
+- inputText: "Swift"
+
+- waitForAnimationToEnd
+
+# 検索結果に本が表示されることを確認
+- assertVisible:
+    text: ".*Swift.*"

--- a/.maestro/settings/01_settings_navigation.yaml
+++ b/.maestro/settings/01_settings_navigation.yaml
@@ -1,0 +1,11 @@
+appId: com.bivre.bookshelf.develop
+---
+- runFlow: ../common/flows/_open_app.yaml
+
+# 設定タブへ遷移
+- tapOn: "設定"
+
+- waitForAnimationToEnd
+
+# 設定画面の要素を確認
+- assertVisible: "設定"

--- a/.maestro/statistics/01_statistics_view.yaml
+++ b/.maestro/statistics/01_statistics_view.yaml
@@ -1,0 +1,11 @@
+appId: com.bivre.bookshelf.develop
+---
+- runFlow: ../common/flows/_open_app.yaml
+
+# 統計タブへ遷移
+- tapOn: "振り返り"
+
+- waitForAnimationToEnd
+
+# 統計画面の要素を確認
+- assertVisible: "振り返り"

--- a/.maestro/statistics/02_statistics_year_switch.yaml
+++ b/.maestro/statistics/02_statistics_year_switch.yaml
@@ -1,0 +1,20 @@
+appId: com.bivre.bookshelf.develop
+---
+- runFlow: ../common/flows/_open_app.yaml
+
+# 統計タブへ遷移
+- tapOn: "振り返り"
+
+- waitForAnimationToEnd
+
+# 前年へ切り替え
+- tapOn:
+    id: "chevron.backward"
+
+- waitForAnimationToEnd
+
+# 翌年で元に戻す
+- tapOn:
+    id: "chevron.forward"
+
+- waitForAnimationToEnd


### PR DESCRIPTION
## 概要
Maestro E2E テストを smoke の3フローから拡充し、主要ユーザーフローをカバーする。

## 追加したフロー
### 共通
- `_common/_add_sample_book.yaml` — テスト用の本を追加する共通フロー

### CRUD（crud/）
- `01_book_detail_view.yaml` — 本の詳細画面表示・要素確認
- `02_book_delete.yaml` — 本の削除フロー

### 検索（search/）
- `01_shelf_search.yaml` — 本棚での検索機能

### 統計（statistics/）
- `01_statistics_view.yaml` — 統計画面の表示確認
- `02_statistics_year_switch.yaml` — 年の前後切り替え

### 設定（settings/）
- `01_settings_navigation.yaml` — 設定画面の表示確認

## その他
- `config.yaml` に新ディレクトリを追加
- CI タイムアウトを 120s → 300s に引き上げ

## 今後の拡充予定
- タグの CRUD（crud/04-06）
- 検索結果なしの確認、タグフィルタ
- バーコードスキャン（モック実装後）

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for book management, search, settings, and statistics functionality.
  * Improved test stability with increased timeout thresholds for reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->